### PR TITLE
increase http client timeout

### DIFF
--- a/drpg/api.py
+++ b/drpg/api.py
@@ -43,7 +43,7 @@ class DrpgApi:
     API_URL = "https://www.drivethrurpg.com"
 
     def __init__(self, api_key: str):
-        self._client = httpx.Client(base_url=self.API_URL)
+        self._client = httpx.Client(base_url=self.API_URL, timeout=30.0)
         self._api_key = api_key
         self._customer_id = None
 

--- a/drpg/sync.py
+++ b/drpg/sync.py
@@ -74,7 +74,7 @@ class DrpgSync:
         logger.info("Processing: %s - %s", product["products_name"], item["filename"])
 
         url_data = self._api.file_task(product["products_id"], item["bundle_id"])
-        file_response = httpx.get(url_data["download_url"])
+        file_response = httpx.get(url_data["download_url"], timeout=30.0)
 
         path = self._file_path(product, item)
         path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
sometimes the drpg api is slow and the default timeout is too short, this increase helps resolve those issues