### PR TITLE
Run tests on correct Python versions

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13.0-alpha.2']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13.0-alpha.5']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13.0-alpha.5']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13.0-alpha.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -21,10 +21,10 @@ jobs:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    - uses: pre-commit/action@v3.0.1
     - name: Install dependencies
       run: |
         pip install -r requirements.dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "respx",
     "pip-tools",
     "tox",
+    "tox-gh-actions",
 ]
 
 [project.scripts]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -86,6 +86,10 @@ tomli==2.0.1
     #   pyproject-hooks
     #   tox
 tox==4.13.0
+    # via
+    #   drpg (pyproject.toml)
+    #   tox-gh-actions
+tox-gh-actions==3.2.0
     # via drpg (pyproject.toml)
 typing-extensions==4.9.0
     # via anyio

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,24 @@
 [tox]
 skipsdist = true
 envlist =
-    py3-httpx{020,100b0}-respx018
-    py3-httpx{021,022,023,024,025,026,027}-respx020
+    py{38,39,310,311,312}-httpx{020,100b0}-respx018
+    py{38,39,310,311,312}-httpx{021,022}-respx020
+    py{38,39,310,311,312,313}-httpx{023,024,025,026,027}-respx020
+
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
 
 [testenv]
-download = True
 set_env =
     VIRTUALENV_PIP=23.1.2
 deps =
-    py3: .
+    py: .
     httpx020: httpx>=0.20,<0.21
     httpx021: httpx>=0.21,<0.22
     httpx022: httpx>=0.22,<0.23


### PR DESCRIPTION
There was a bug in the workflow file, causing tests that were not run on different Python versions. Luckily, after fixing it, the drpg test suit passes on all Python versions but 3.13 alpha.

Fixing failing tests on 3.13a should be easy. It's just a matter of not using old httpx versions.