### PR TITLE
add --omit-publisher to omit publisher part of the path

### DIFF
--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -77,7 +77,7 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
     )
 
     compability_group = parser.add_mutually_exclusive_group()
-    
+
     compability_group.add_argument(
         "--compatibility-mode",
         action="store_true",

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -81,6 +81,12 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         default=environ.get("DRPG_COMPATIBILITY_MODE", "false").lower() == "true",
         help="Name files and directories the way that DriveThruRPG's client app does.",
     )
+    parser.add_argument(
+        "--omit-publisher",
+        action="store_true",
+        default=environ.get("DRPG_OMIT_PUBLISHER", "false").lower() == "true",
+        help="Omit the publisher name in the target path.",
+    )
 
     return parser.parse_args(args, namespace=Config())
 

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -75,13 +75,16 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         default=environ.get("DRPG_DRY_RUN", "false").lower() == "true",
         help="Determine what should be downloaded, but do not download it. Defaults to false",
     )
-    parser.add_argument(
+
+    compability_group = parser.add_mutually_exclusive_group()
+    
+    compability_group.add_argument(
         "--compatibility-mode",
         action="store_true",
         default=environ.get("DRPG_COMPATIBILITY_MODE", "false").lower() == "true",
         help="Name files and directories the way that DriveThruRPG's client app does.",
     )
-    parser.add_argument(
+    compability_group.add_argument(
         "--omit-publisher",
         action="store_true",
         default=environ.get("DRPG_OMIT_PUBLISHER", "false").lower() == "true",

--- a/drpg/config.py
+++ b/drpg/config.py
@@ -12,3 +12,4 @@ class Config:
     log_level: str
     dry_run: bool
     compatibility_mode: bool
+    omit_publisher: bool

--- a/drpg/sync.py
+++ b/drpg/sync.py
@@ -52,6 +52,7 @@ class DrpgSync:
         self._library_path = config.library_path
         self._dry_run = config.dry_run
         self._compatibility_mode = config.compatibility_mode
+        self._omit_publisher = config.omit_publisher
         self._api = DrpgApi(config.token)
 
     def sync(self) -> None:
@@ -126,7 +127,10 @@ class DrpgSync:
         )
         product_name = _normalize_path_part(product["products_name"], self._compatibility_mode)
         item_name = _normalize_path_part(item["filename"], self._compatibility_mode)
-        return self._library_path / publishers_name / product_name / item_name
+        if  not self._omit_publisher:
+            return self._library_path / publishers_name / product_name / item_name
+        else:
+            return self._library_path / product_name / item_name
 
 
 def _normalize_path_part(part: str, compatibility_mode: bool) -> str:

--- a/drpg/sync.py
+++ b/drpg/sync.py
@@ -127,7 +127,7 @@ class DrpgSync:
         )
         product_name = _normalize_path_part(product["products_name"], self._compatibility_mode)
         item_name = _normalize_path_part(item["filename"], self._compatibility_mode)
-        if  not self._omit_publisher:
+        if not self._omit_publisher:
             return self._library_path / publishers_name / product_name / item_name
         else:
             return self._library_path / product_name / item_name

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -35,6 +35,10 @@ class ParseCliTest(TestCase):
         self.assertTrue(config.compatibility_mode)
         self.assertTrue(config.omit_publisher)
 
+    @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
+    def test_compability_mutually_exclusive_group(self, error_mock):
+        cmd._parse_cli(['--compatibility-mode', '--omit-publisher', '--token', 'mock_token'])
+        error_mock.assert_called()
 
 class SignalHandlerTest(TestCase):
     @mock.patch("drpg.cmd.sys.exit")

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -37,8 +37,9 @@ class ParseCliTest(TestCase):
 
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_compability_mutually_exclusive_group(self, error_mock):
-        cmd._parse_cli(['--compatibility-mode', '--omit-publisher', '--token', 'mock_token'])
+        cmd._parse_cli(["--compatibility-mode", "--omit-publisher", "--token", "mock_token"])
         error_mock.assert_called()
+
 
 class SignalHandlerTest(TestCase):
     @mock.patch("drpg.cmd.sys.exit")

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -21,6 +21,7 @@ class ParseCliTest(TestCase):
             "DRPG_USE_CHECKSUMS": "true",
             "DRPG_DRY_RUN": "true",
             "DRPG_COMPATIBILITY_MODE": "true",
+            "DRPG_OMIT_PUBLISHER": "true",
         }
 
         with mock.patch.dict(cmd.environ, env):
@@ -32,6 +33,7 @@ class ParseCliTest(TestCase):
         self.assertTrue(config.use_checksums)
         self.assertTrue(config.dry_run)
         self.assertTrue(config.compatibility_mode)
+        self.assertTrue(config.omit_publisher)
 
 
 class SignalHandlerTest(TestCase):

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,8 +1,9 @@
+import sys
 from inspect import currentframe
 from os.path import expandvars
 from pathlib import Path
 from signal import SIGTERM
-from unittest import TestCase, mock
+from unittest import TestCase, mock, skipIf
 
 from drpg import cmd
 
@@ -35,6 +36,7 @@ class ParseCliTest(TestCase):
         self.assertTrue(config.compatibility_mode)
         self.assertTrue(config.omit_publisher)
 
+    @skipIf(sys.version_info < (3, 9), "Python 3.8 EOL")
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_compability_mutually_exclusive_group(self, error_mock):
         cmd._parse_cli(["--compatibility-mode", "--omit-publisher", "--token", "mock_token"])

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -22,6 +22,7 @@ class dummy_config:
     library_path = Path("./test_library")
     dry_run = False
     compatibility_mode = False
+    omit_publisher = False
 
 
 PathMock = partial(mock.Mock, spec=Path)


### PR DESCRIPTION
I added the option to omit the publisher part of the path to flatten the hierarchy and make the directory more intuitively searchable imho.

The wheel was tested successfully.

Already downloaded files can be moved with `find ./DriveThruRPG/ -maxdepth 2 -mindepth 2 -type d -print0 | xargs -0 -I {} mv -v "{}" ./DriveThruRPG`
Empty publisher folders can be deleted with `find ./DriveThruRPG/ -empty -type d -delete` afterwards.