### PR TITLE
Mark README as needing 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-This script runs with Python 3.9 and newer.
+This script runs with Python 3.10 and newer.
 
 You can install dRPG from PyPI:
 ```bash


### PR DESCRIPTION
The `pyproject.toml` and most of the rest of the repo says 3.10, but the README still said 3.9