### PR TITLE
Adds config file option

### DIFF
--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -52,7 +52,9 @@ class ConfigFileAction(argparse.Action):
         cp = configparser.ConfigParser(allow_unnamed_section=True)
         with config_file.open() as cf:
             cp.read_file(cf)
-            section = cp[configparser.UNNAMED_SECTION]
+            if "drpg" not in cp.sections():
+                raise argparse.ArgumentError(self, f"No drpg section in '{config_file}'")
+            section = cp["drpg"]
             for key in dataclasses.fields(Config):
                 if key.type == "bool":
                     value = section.getboolean(key.name)

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -49,7 +49,7 @@ class ConfigFileAction(argparse.Action):
         config_file = cast(Path, values)
         if not config_file.exists():
             raise argparse.ArgumentError(self, f"No such config file '{config_file}'")
-        cp = configparser.ConfigParser(allow_unnamed_section=True)
+        cp = configparser.ConfigParser()
         with config_file.open() as cf:
             cp.read_file(cf)
             if "drpg" not in cp.sections():

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -48,7 +48,7 @@ class ConfigFileAction(argparse.Action):
         config_file = cast(Path, values)
         if not config_file.exists():
             raise argparse.ArgumentError(self, f"No such config file '{config_file}'")
-        cp = configparser.ConfigParser(allow_unnamed_section=True)
+        cp = configparser.ConfigParser()
         with config_file.open() as cf:
             cp.read_file(cf)
             if "drpg" not in cp.sections():

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -51,7 +51,9 @@ class ConfigFileAction(argparse.Action):
         cp = configparser.ConfigParser(allow_unnamed_section=True)
         with config_file.open() as cf:
             cp.read_file(cf)
-            section = cp[configparser.UNNAMED_SECTION]
+            if "drpg" not in cp.sections():
+                raise argparse.ArgumentError(self, f"No drpg section in '{config_file}'")
+            section = cp["drpg"]
             for key in dataclasses.fields(Config):
                 if key.type == "bool":
                     value = section.getboolean(key.name)

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import dataclasses
 import logging
 import os.path
 import platform
@@ -12,7 +13,7 @@ import threading
 from os import environ
 from pathlib import Path
 from traceback import format_exception
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import drpg
 from drpg.config import Config
@@ -41,6 +42,32 @@ def run() -> None:
         sync.sync()
 
 
+class ConfigFileAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values is None:
+            raise argparse.ArgumentError(self, "No config file specified")
+        config_file = cast(Path, values)
+        if not config_file.exists():
+            raise argparse.ArgumentError(self, f"No such config file '{config_file}'")
+        cp = configparser.ConfigParser(allow_unnamed_section=True)
+        with config_file.open() as cf:
+            cp.read_file(cf)
+            section = cp[configparser.UNNAMED_SECTION]
+            for key in dataclasses.fields(Config):
+                if key.type == "bool":
+                    value = section.getboolean(key.name)
+                elif key.type == "int":
+                    value = section.getint(key.name)
+                elif key.type == "Path":
+                    value = section.get(key.name)
+                    if value is not None:
+                        value = Path(value)
+                else:
+                    value = section.get(key.name)
+                if value is not None:
+                    setattr(namespace, key.name, value)
+
+
 def _parse_cli(args: CliArgs | None = None) -> Config:
     parser = argparse.ArgumentParser(
         prog="drpg",
@@ -55,9 +82,14 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         """,
     )
     parser.add_argument(
+        "--config",
+        help="Read settings from config file for DRPG",
+        type=Path,
+        action=ConfigFileAction,
+    )
+    parser.add_argument(
         "--token",
         "-t",
-        required="DRPG_TOKEN" not in environ,
         help="Required. Your DriveThruRPG API token",
         default=environ.get("DRPG_TOKEN"),
     )
@@ -109,22 +141,28 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         help="Disable checking for updated version",
     )
 
-    compability_group = parser.add_mutually_exclusive_group()
-
-    compability_group.add_argument(
+    parser.add_argument(
         "--compatibility-mode",
         action="store_true",
         default=environ.get("DRPG_COMPATIBILITY_MODE", "false").lower() == "true",
         help="Name files and directories the way that DriveThruRPG's client app does.",
     )
-    compability_group.add_argument(
+    parser.add_argument(
         "--omit-publisher",
         action="store_true",
         default=environ.get("DRPG_OMIT_PUBLISHER", "false").lower() == "true",
         help="Omit the publisher name in the target path.",
     )
 
-    return Config.from_namespace(parser.parse_args(args))
+    namespace = parser.parse_args(args)
+
+    # Done here so we can let the config parser set these, and still catch the issues
+    if namespace.token is None:
+        parser.error("--token/-t argument is required")
+    if namespace.compatibility_mode is True and namespace.omit_publisher is True:
+        parser.error("Can only set compatibility-mode *or* omit-publisher, not both")
+
+    return Config.from_namespace(namespace)
 
 
 def _default_dir() -> Path:

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -43,7 +43,7 @@ def run() -> None:
 
 
 class ConfigFileAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser, namespace, values, option_string=None):  # noqa: C901
         if values is None:
             raise argparse.ArgumentError(self, "No config file specified")
         config_file = cast(Path, values)
@@ -55,6 +55,7 @@ class ConfigFileAction(argparse.Action):
             if "drpg" not in cp.sections():
                 raise argparse.ArgumentError(self, f"No drpg section in '{config_file}'")
             section = cp["drpg"]
+            keys = set(section.keys())
             for key in dataclasses.fields(Config):
                 if key.type == "bool":
                     value = section.getboolean(key.name)
@@ -66,8 +67,13 @@ class ConfigFileAction(argparse.Action):
                         value = Path(value)
                 else:
                     value = section.get(key.name)
+                keys.discard(key.name)
                 if value is not None:
                     setattr(namespace, key.name, value)
+            if len(keys) != 0:
+                raise argparse.ArgumentError(
+                    self, "Unsupported config keys: %s" % (", ".join(sorted(keys)))
+                )
 
 
 def _parse_cli(args: CliArgs | None = None) -> Config:

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import dataclasses
 import logging
 import os.path
 import platform
@@ -12,7 +13,7 @@ import threading
 from os import environ
 from pathlib import Path
 from traceback import format_exception
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import drpg
 from drpg.config import Config
@@ -40,6 +41,32 @@ def run() -> None:
         sync.sync()
 
 
+class ConfigFileAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values is None:
+            raise argparse.ArgumentError(self, "No config file specified")
+        config_file = cast(Path, values)
+        if not config_file.exists():
+            raise argparse.ArgumentError(self, f"No such config file '{config_file}'")
+        cp = configparser.ConfigParser(allow_unnamed_section=True)
+        with config_file.open() as cf:
+            cp.read_file(cf)
+            section = cp[configparser.UNNAMED_SECTION]
+            for key in dataclasses.fields(Config):
+                if key.type == "bool":
+                    value = section.getboolean(key.name)
+                elif key.type == "int":
+                    value = section.getint(key.name)
+                elif key.type == "Path":
+                    value = section.get(key.name)
+                    if value is not None:
+                        value = Path(value)
+                else:
+                    value = section.get(key.name)
+                if value is not None:
+                    setattr(namespace, key.name, value)
+
+
 def _parse_cli(args: CliArgs | None = None) -> Config:
     parser = argparse.ArgumentParser(
         prog="drpg",
@@ -54,9 +81,14 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         """,
     )
     parser.add_argument(
+        "--config",
+        help="Read settings from config file for DRPG",
+        type=Path,
+        action=ConfigFileAction,
+    )
+    parser.add_argument(
         "--token",
         "-t",
-        required="DRPG_TOKEN" not in environ,
         help="Required. Your DriveThruRPG API token",
         default=environ.get("DRPG_TOKEN"),
     )
@@ -101,22 +133,28 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         help="Determine what should be downloaded, but do not download it. Defaults to false",
     )
 
-    compability_group = parser.add_mutually_exclusive_group()
-
-    compability_group.add_argument(
+    parser.add_argument(
         "--compatibility-mode",
         action="store_true",
         default=environ.get("DRPG_COMPATIBILITY_MODE", "false").lower() == "true",
         help="Name files and directories the way that DriveThruRPG's client app does.",
     )
-    compability_group.add_argument(
+    parser.add_argument(
         "--omit-publisher",
         action="store_true",
         default=environ.get("DRPG_OMIT_PUBLISHER", "false").lower() == "true",
         help="Omit the publisher name in the target path.",
     )
 
-    return Config.from_namespace(parser.parse_args(args))
+    namespace = parser.parse_args(args)
+
+    # Done here so we can let the config parser set these, and still catch the issues
+    if namespace.token is None:
+        parser.error("--token/-t argument is required")
+    if namespace.compatibility_mode is True and namespace.omit_publisher is True:
+        parser.error("Can only set compatibility-mode *or* omit-publisher, not both")
+
+    return Config.from_namespace(namespace)
 
 
 def _default_dir() -> Path:

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -8,11 +8,14 @@ from unittest import TestCase, mock
 from httpx import URL
 
 from drpg import cmd
+from drpg.config import Config
 
 
 class ParseCliTest(TestCase):
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_has_required_params(self, error_mock):
+        # Because otherwise this breaks with environments that already have things set
+        cmd.environ.clear()
         cmd._parse_cli([])
         error_mock.assert_called_once()
 
@@ -26,7 +29,7 @@ class ParseCliTest(TestCase):
             "DRPG_DRY_RUN": "true",
             "DRPG_THREADS": "1",
             "DRPG_COMPATIBILITY_MODE": "true",
-            "DRPG_OMIT_PUBLISHER": "true",
+            "DRPG_OMIT_PUBLISHER": "false",
             "DRPG_NO_CHECK": "true",
         }
 
@@ -41,13 +44,29 @@ class ParseCliTest(TestCase):
         self.assertTrue(config.dry_run)
         self.assertEqual(config.threads, int(env["DRPG_THREADS"]))
         self.assertTrue(config.compatibility_mode)
-        self.assertTrue(config.omit_publisher)
+        self.assertFalse(config.omit_publisher)
         self.assertFalse(config.do_check)
 
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_compability_mutually_exclusive_group(self, error_mock):
         cmd._parse_cli(["--compatibility-mode", "--omit-publisher", "--token", "mock_token"])
         error_mock.assert_called()
+
+    def test_config_file_parse(self):
+        config = cmd._parse_cli(
+            ["--config", Path(__file__).parent.joinpath("test_config.ini").as_posix()]
+        )
+        assert config == Config(
+            token="supersecrettoken",
+            library_path=Path("/a/nother/path"),
+            use_checksums=True,
+            validate=True,
+            log_level="DEBUG",
+            dry_run=True,
+            compatibility_mode=True,
+            omit_publisher=False,
+            threads=10,
+        ), config
 
 
 class SignalHandlerTest(TestCase):

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,4 +1,5 @@
 import logging
+import tempfile
 import threading
 from inspect import currentframe
 from os.path import expandvars
@@ -68,6 +69,16 @@ class ParseCliTest(TestCase):
             omit_publisher=False,
             threads=10,
         ), config
+
+    @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
+    def test_config_file_bad_parse(self, error_mock: mock.MagicMock):
+        test_config_path = Path(__file__).parent.joinpath("test_config.ini")
+        with tempfile.NamedTemporaryFile(mode="w") as bad_config_file:
+            bad_config_file.write(test_config_path.open().read())
+            bad_config_file.write("\nextra_arg=foo\n")
+            bad_config_file.flush()
+            cmd._parse_cli(["--config", bad_config_file.name])
+            error_mock.assert_any_call("argument --config: Unsupported config keys: extra_arg")
 
 
 class SignalHandlerTest(TestCase):

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -8,11 +8,14 @@ from unittest import TestCase, mock
 from httpx import URL
 
 from drpg import cmd
+from drpg.config import Config
 
 
 class ParseCliTest(TestCase):
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_has_required_params(self, error_mock):
+        # Because otherwise this breaks with environments that already have things set
+        cmd.environ.clear()
         cmd._parse_cli([])
         error_mock.assert_called_once()
 
@@ -26,7 +29,7 @@ class ParseCliTest(TestCase):
             "DRPG_DRY_RUN": "true",
             "DRPG_THREADS": "1",
             "DRPG_COMPATIBILITY_MODE": "true",
-            "DRPG_OMIT_PUBLISHER": "true",
+            "DRPG_OMIT_PUBLISHER": "false",
         }
 
         with mock.patch.dict(cmd.environ, env):
@@ -40,12 +43,28 @@ class ParseCliTest(TestCase):
         self.assertTrue(config.dry_run)
         self.assertEqual(config.threads, int(env["DRPG_THREADS"]))
         self.assertTrue(config.compatibility_mode)
-        self.assertTrue(config.omit_publisher)
+        self.assertFalse(config.omit_publisher)
 
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_compability_mutually_exclusive_group(self, error_mock):
         cmd._parse_cli(["--compatibility-mode", "--omit-publisher", "--token", "mock_token"])
         error_mock.assert_called()
+
+    def test_config_file_parse(self):
+        config = cmd._parse_cli(
+            ["--config", Path(__file__).parent.joinpath("test_config.ini").as_posix()]
+        )
+        assert config == Config(
+            token="supersecrettoken",
+            library_path=Path("/a/nother/path"),
+            use_checksums=True,
+            validate=True,
+            log_level="DEBUG",
+            dry_run=True,
+            compatibility_mode=True,
+            omit_publisher=False,
+            threads=10,
+        ), config
 
 
 class SignalHandlerTest(TestCase):

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,0 +1,9 @@
+token=supersecrettoken
+library_path=/a/nother/path
+checksums=true
+validate=true
+log_level=DEBUG
+dry_run=True
+compatibility_mode=True
+omit_publisher=False
+threads=10

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,3 +1,4 @@
+[drpg]
 token=supersecrettoken
 library_path=/a/nother/path
 use_checksums=true

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,6 +1,6 @@
 token=supersecrettoken
 library_path=/a/nother/path
-checksums=true
+use_checksums=true
 validate=true
 log_level=DEBUG
 dry_run=True


### PR DESCRIPTION
Fixes #150

Answering the questions from that issue:
* Config file values are exactly the same as the argument parser values. ~~It'll effectively ignore anything you set that isn't supported.~~ It now throws errors if you set something unsupported, as it was annoying trying to figure things out.
* Order of preference is that environment variables are the defaults, and both config file and other arguments can override that. Arguments can override config file and vice versa by being later in the list of arguments.
* Format is INI, purely because Python has built-in support.
* Config file location isn't defined on a platform basis, purely on a command line arg basis.