### PR TITLE
File rewrite map

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,5 @@ max-line-length = 100
 extend-exclude =
     .ropeproject,
     venv
+# Because Black, see https://github.com/psf/black/issues/315
+ignore = E203,W503

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -48,7 +48,7 @@ class ConfigFileAction(argparse.Action):
         config_file = cast(Path, values)
         if not config_file.exists():
             raise argparse.ArgumentError(self, f"No such config file '{config_file}'")
-        cp = configparser.ConfigParser(allow_unnamed_section=True)
+        cp = configparser.ConfigParser()
         with config_file.open() as cf:
             cp.read_file(cf)
             if "drpg" not in cp.sections():

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -59,7 +59,7 @@ class ConfigFileAction(argparse.Action):
                     value = section.getboolean(key.name)
                 elif key.type == "int":
                     value = section.getint(key.name)
-                elif key.type == "Path":
+                elif key.type in ["Path", "Path | None"]:
                     value = section.get(key.name)
                     if value is not None:
                         value = Path(value)
@@ -146,6 +146,12 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         action="store_true",
         default=environ.get("DRPG_OMIT_PUBLISHER", "false").lower() == "true",
         help="Omit the publisher name in the target path.",
+    )
+    parser.add_argument(
+        "--rewrite-folder-names",
+        type=Path,
+        default=environ.get("DRPG_REWRITE_FOLDER_NAMES"),
+        help="Add rewrite table for folder names",
     )
 
     namespace = parser.parse_args(args)

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -51,7 +51,9 @@ class ConfigFileAction(argparse.Action):
         cp = configparser.ConfigParser(allow_unnamed_section=True)
         with config_file.open() as cf:
             cp.read_file(cf)
-            section = cp[configparser.UNNAMED_SECTION]
+            if "drpg" not in cp.sections():
+                raise argparse.ArgumentError(self, f"No drpg section in '{config_file}'")
+            section = cp["drpg"]
             for key in dataclasses.fields(Config):
                 if key.type == "bool":
                     value = section.getboolean(key.name)

--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import dataclasses
 import logging
 import os.path
 import platform
@@ -12,7 +13,7 @@ import threading
 from os import environ
 from pathlib import Path
 from traceback import format_exception
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import drpg
 from drpg.config import Config
@@ -40,6 +41,32 @@ def run() -> None:
         sync.sync()
 
 
+class ConfigFileAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values is None:
+            raise argparse.ArgumentError(self, "No config file specified")
+        config_file = cast(Path, values)
+        if not config_file.exists():
+            raise argparse.ArgumentError(self, f"No such config file '{config_file}'")
+        cp = configparser.ConfigParser(allow_unnamed_section=True)
+        with config_file.open() as cf:
+            cp.read_file(cf)
+            section = cp[configparser.UNNAMED_SECTION]
+            for key in dataclasses.fields(Config):
+                if key.type == "bool":
+                    value = section.getboolean(key.name)
+                elif key.type == "int":
+                    value = section.getint(key.name)
+                elif key.type == "Path":
+                    value = section.get(key.name)
+                    if value is not None:
+                        value = Path(value)
+                else:
+                    value = section.get(key.name)
+                if value is not None:
+                    setattr(namespace, key.name, value)
+
+
 def _parse_cli(args: CliArgs | None = None) -> Config:
     parser = argparse.ArgumentParser(
         prog="drpg",
@@ -54,9 +81,14 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         """,
     )
     parser.add_argument(
+        "--config",
+        help="Read settings from config file for DRPG",
+        type=Path,
+        action=ConfigFileAction,
+    )
+    parser.add_argument(
         "--token",
         "-t",
-        required="DRPG_TOKEN" not in environ,
         help="Required. Your DriveThruRPG API token",
         default=environ.get("DRPG_TOKEN"),
     )
@@ -101,22 +133,28 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         help="Determine what should be downloaded, but do not download it. Defaults to false",
     )
 
-    compability_group = parser.add_mutually_exclusive_group()
-
-    compability_group.add_argument(
+    parser.add_argument(
         "--compatibility-mode",
         action="store_true",
         default=environ.get("DRPG_COMPATIBILITY_MODE", "false").lower() == "true",
         help="Name files and directories the way that DriveThruRPG's client app does.",
     )
-    compability_group.add_argument(
+    parser.add_argument(
         "--omit-publisher",
         action="store_true",
         default=environ.get("DRPG_OMIT_PUBLISHER", "false").lower() == "true",
         help="Omit the publisher name in the target path.",
     )
 
-    return Config.from_namespace(parser.parse_args(args))
+    namespace = parser.parse_args(args)
+
+    # Done here so we can let the config parser set these, and still catch the issues
+    if namespace.token is None:
+        parser.error("--token/-t argument is required")
+    if namespace.compatibility_mode is True and namespace.omit_publisher is True:
+        parser.error("Can only set compatibility-mode *or* omit-publisher, not both")
+
+    return Config.from_namespace(namespace)
 
 
 def _default_dir() -> Path:

--- a/drpg/config.py
+++ b/drpg/config.py
@@ -16,6 +16,7 @@ class Config:
     compatibility_mode: bool = False
     omit_publisher: bool = False
     threads: int = 5
+    rewrite_folder_names: Path | None = None
 
     @classmethod
     def from_namespace(cls, namespace: Any) -> Config:
@@ -30,4 +31,5 @@ class Config:
             compatibility_mode=namespace.compatibility_mode,
             omit_publisher=namespace.omit_publisher,
             threads=namespace.threads,
+            rewrite_folder_names=namespace.rewrite_folder_names,
         )

--- a/drpg/sync.py
+++ b/drpg/sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import configparser
 import functools
 import html
 import logging
@@ -8,6 +9,7 @@ import threading
 from datetime import datetime, timedelta
 from hashlib import md5
 from multiprocessing.pool import ThreadPool
+from pathlib import Path
 from time import timezone
 from typing import TYPE_CHECKING
 
@@ -16,7 +18,6 @@ import httpx
 from drpg.api import DrpgApi
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pathlib import Path
     from typing import Any, Callable
 
     from drpg.config import Config
@@ -52,6 +53,15 @@ class DrpgSync:
         self._api = DrpgApi(config.token)
         self._shutdown_event = threading.Event()
         self._download_client = httpx.Client(timeout=30.0)
+        if config.rewrite_folder_names is None:
+            self.rewrites = {}
+        else:
+            cp = configparser.ConfigParser()
+            with config.rewrite_folder_names.open() as cf:
+                cp.read_file(cf)
+                if "rewrite" not in cp.sections():
+                    raise Exception(f"No 'rewrite' section in '{config.rewrite_folder_names}")
+                self.rewrites = dict(cp.items("rewrite"))
 
     def __enter__(self) -> DrpgSync:
         return self
@@ -173,9 +183,27 @@ class DrpgSync:
         product_name = _normalize_path_part(product["name"], self._config.compatibility_mode)
         item_name = _normalize_path_part(item["filename"], self._config.compatibility_mode)
         if self._config.omit_publisher:
-            return self._config.library_path / product_name / item_name
+            return_path = self._config.library_path / product_name / item_name
         else:
-            return self._config.library_path / publishers_name / product_name / item_name
+            return_path = self._config.library_path / publishers_name / product_name / item_name
+
+        return_path_str = return_path.as_posix()
+        for key, value in self.rewrites.items():
+            # Keys are always lower case because ini files
+            lower_return_path = return_path_str.lower()
+
+            # We need to do this in a complicated way as the keys are not case sensitive
+            start_index = lower_return_path.find(key)
+            if start_index != -1:
+                new_return_path = (
+                    return_path_str[:start_index]
+                    + value
+                    + return_path_str[start_index + len(key) :]
+                )
+                logger.debug("rewriting %s -> %s", return_path_str, new_return_path)
+                return_path_str = new_return_path
+
+        return Path(return_path_str)
 
 
 def _normalize_path_part(part: str, compatibility_mode: bool) -> str:

--- a/drpg/sync.py
+++ b/drpg/sync.py
@@ -53,9 +53,8 @@ class DrpgSync:
         self._api = DrpgApi(config.token)
         self._shutdown_event = threading.Event()
         self._download_client = httpx.Client(timeout=30.0)
-        if config.rewrite_folder_names is None:
-            self.rewrites = {}
-        else:
+        self.rewrites: dict[str, str] = {}
+        if config.rewrite_folder_names is not None:
             cp = configparser.ConfigParser()
             with config.rewrite_folder_names.open() as cf:
                 cp.read_file(cf)
@@ -63,7 +62,10 @@ class DrpgSync:
                     raise configparser.Error(
                         f"No 'rewrite' section in '{config.rewrite_folder_names}"
                     )
-                self.rewrites = dict(cp.items("rewrite"))
+                for key, value in cp.items("rewrite"):
+                    if key.startswith('"') and key.endswith('"'):
+                        key = key[1:-1]
+                    self.rewrites[key] = value
 
     def __enter__(self) -> DrpgSync:
         return self

--- a/drpg/sync.py
+++ b/drpg/sync.py
@@ -60,7 +60,9 @@ class DrpgSync:
             with config.rewrite_folder_names.open() as cf:
                 cp.read_file(cf)
                 if "rewrite" not in cp.sections():
-                    raise Exception(f"No 'rewrite' section in '{config.rewrite_folder_names}")
+                    raise configparser.Error(
+                        f"No 'rewrite' section in '{config.rewrite_folder_names}"
+                    )
                 self.rewrites = dict(cp.items("rewrite"))
 
     def __enter__(self) -> DrpgSync:

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -8,11 +8,14 @@ from unittest import TestCase, mock
 from httpx import URL
 
 from drpg import cmd
+from drpg.config import Config
 
 
 class ParseCliTest(TestCase):
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_has_required_params(self, error_mock):
+        # Because otherwise this breaks with environments that already have things set
+        cmd.environ.clear()
         cmd._parse_cli([])
         error_mock.assert_called_once()
 
@@ -26,7 +29,7 @@ class ParseCliTest(TestCase):
             "DRPG_DRY_RUN": "true",
             "DRPG_THREADS": "1",
             "DRPG_COMPATIBILITY_MODE": "true",
-            "DRPG_OMIT_PUBLISHER": "true",
+            "DRPG_OMIT_PUBLISHER": "false",
         }
 
         with mock.patch.dict(cmd.environ, env):
@@ -40,12 +43,28 @@ class ParseCliTest(TestCase):
         self.assertTrue(config.dry_run)
         self.assertEqual(config.threads, int(env["DRPG_THREADS"]))
         self.assertTrue(config.compatibility_mode)
-        self.assertTrue(config.omit_publisher)
+        self.assertFalse(config.omit_publisher)
 
     @mock.patch("drpg.cmd.argparse.ArgumentParser.error")
     def test_compability_mutually_exclusive_group(self, error_mock):
         cmd._parse_cli(["--compatibility-mode", "--omit-publisher", "--token", "mock_token"])
         error_mock.assert_called()
+
+    def test_config_file_parse(self):
+        config = cmd._parse_cli(
+            ["--config", Path(__file__).parent.joinpath("test_config.ini").as_posix()]
+        )
+        assert config == Config(
+            token="supersecrettoken",
+            library_path=Path("/a/nother/path"),
+            use_checksums=True,
+            validate=True,
+            log_level="DEBUG",
+            dry_run=True,
+            compatibility_mode=True,
+            omit_publisher=False,
+            threads=10,
+        ), config
 
 
 class SignalHandlerTest(TestCase):

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -8,3 +8,6 @@ dry_run=True
 compatibility_mode=True
 omit_publisher=False
 threads=10
+
+[rewrite]
+Unit Publishing/Rulebook=NewName

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,0 +1,9 @@
+token=supersecrettoken
+library_path=/a/nother/path
+checksums=true
+validate=true
+log_level=DEBUG
+dry_run=True
+compatibility_mode=True
+omit_publisher=False
+threads=10

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,3 +1,4 @@
+[drpg]
 token=supersecrettoken
 library_path=/a/nother/path
 use_checksums=true

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,6 +1,6 @@
 token=supersecrettoken
 library_path=/a/nother/path
-checksums=true
+use_checksums=true
 validate=true
 log_level=DEBUG
 dry_run=True

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -25,6 +25,7 @@ class dummy_config:
     threads = 5
     compatibility_mode = False
     omit_publisher = False
+    rewrite_folder_names: Path | None = None
 
 
 PathMock = partial(mock.Mock, spec=Path)
@@ -181,6 +182,20 @@ class DrpgSyncFilePathTest(TestCase):
         config.omit_publisher = False
         path = drpg.DrpgSync(config)._file_path(product, item)
         self.assertIn(publisher, str(path))
+
+    def test_rewrite(self):
+        publisher = "Unit Publishing"
+        product = {
+            "name": "Rulebook - 2. ed",
+            "publisher": {"name": publisher},
+        }
+        item = {"filename": "filename.pdf"}
+
+        config = dummy_config()
+        config.omit_publisher = False
+        config.rewrite_folder_names = Path(__file__).parent.joinpath("test_config.ini")
+        path = drpg.DrpgSync(config)._file_path(product, item)
+        self.assertIn("NewName", str(path))
 
 
 class DrpgSyncProcessItemTest(TestCase):


### PR DESCRIPTION
Needs https://github.com/glujan/drpg/pull/176 merging first

I have a problem where I don't want to use the publisher name, but I also don't want a million folders called "Legend in the Mist - 5e Crossover Tool", "Legend in the Mist - Action Grimoire", etc, etc; I want one called "Legend in the Mist".

Now, AFAIK there's no easy way to determine automagically what names I want and in some cases what I want is a complete rewrite from the makers names. This PR therefore adds a config option for a `rewrite_folder_names` config, with a `rewrite` section that can look like the following (example taken from part of my local config)

```
[rewrite]
Airship - Ajax 40 - x 20 - RPG Encounter Map=RPG Encounter Map/Airship Ajax
Apocalypse Keys - Doomsday Delights=Apocalypse Keys
Apocalypse World (2nd Ed)=Apocalypse World
Baby Bestiary Handbook Vol 1=Baby Bestiary Handbook/Vol 1
Baby Bestiary Handbook Vol 2=Baby Bestiary Handbook/Vol 2
Call Of Catthulhu, Book II - UNAUSSPRECHLICHEN KATZEN, the Cat Herder's Guide=Call Of Catthulhu
City of Mist - All-Seeing Eye Investigations Soundtrack=City of Mist/All-Seeing Eye Investigations
City of Mist - All-Seeing Eye Investigations Starter Set=City of Mist/All-Seeing Eye Investigations
City of Mist - ASEI Starter Box Assets=City of Mist/All-Seeing Eye Investigations
City of Mist - Case Concept Generator=City of Mist
City of Mist Case - Amensia Town=City of Mist
City of Mist Core Book=City of Mist
```
It will do arbitrary rewrites to the file paths, although generally the target is folder names (and optionally subfolders). All names in the config are matched case-insensitively, in large part because INI file support from configparser drops all the keys to lowercase anyways. Theoretically things like regex support could be useful in the future though. 