### PR TITLE
Improve tests cleanups and coverage

### DIFF
--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -207,6 +207,6 @@ def application_key_filter(record: logging.LogRecord) -> bool:
             masked = re.sub(_APPLICATION_KEY_RE, r"\1******", str(record.args))
             record.msg = f"httpx request: {masked}"
             record.args = ()
-    except Exception:
-        pass
+    except Exception:  # pragma: no cover
+        pass  # I think this is nearly impossible to trigger
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,11 @@ line-length = 100
 
 [tool.coverage.run]
 branch = true
-include = ["drpg/*"]
+include = ["drpg/*","tests/*"]
 omit = [".ropeproject", "venv"]
 
 [tool.coverage.report]
-omit = [".ropeproject", "venv", "tests/*"]
+omit = [".ropeproject", "venv"]
 
 [tool.hatch.version]
 path = "drpg/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,11 @@ line-length = 100
 
 [tool.coverage.run]
 branch = true
-include = ["drpg/*","tests/*"]
+include = ["drpg/*"]
 omit = [".ropeproject", "venv"]
 
 [tool.coverage.report]
-omit = [".ropeproject", "venv"]
+omit = [".ropeproject", "venv", "tests/*"]
 
 [tool.hatch.version]
 path = "drpg/__init__.py"

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from inspect import currentframe
 from os.path import expandvars
 from pathlib import Path
@@ -53,11 +54,23 @@ class ParseCliTest(TestCase):
 class SignalHandlerTest(TestCase):
     @mock.patch("drpg.cmd.sys.exit")
     def test_exits(self, m_exit):
+        cmd._shutdown_event = threading.Event()
         cmd._handle_signal(SIGTERM, currentframe())
         m_exit.assert_called_once_with(0)
 
 
-class SetHttpLogLevel(TestCase):
+class ExceptionHandlerTest(TestCase):
+    @mock.patch("drpg.cmd.logging.getLogger")
+    def test_excepthook(self, m_getLogger: mock.MagicMock):
+        m_logger = mock.MagicMock()
+        m_getLogger.return_value = m_logger
+        cmd._excepthook(Exception, Exception(), None)
+        m_getLogger.assert_called_once_with("drpg")
+        m_logger.error.assert_called_once_with("Unexpected error occurred, stopping!")
+        m_logger.info.assert_called_once_with("Exception\n")
+
+
+class SetLogLevels(TestCase):
     def test_debug(self):
         cmd._set_httpx_log_level(logging.DEBUG)
         self.assertEqual(logging.getLogger("httpx").level, logging.DEBUG)
@@ -71,6 +84,26 @@ class SetHttpLogLevel(TestCase):
                 self.assertEqual(logging.getLogger("httpx").level, logging.WARNING)
                 self.assertEqual(logging.getLogger("httpcore").level, logging.WARNING)
                 self.assertEqual(logging.getLogger("hpack").level, logging.WARNING)
+
+    def clear_handlers(self):
+        # In the actual app, we only ever call basic_config once, but we need to support calling it
+        # multiple times in tests. So clear out the root handlers first. Code is as per the
+        # force=True arg for basic_config.
+        for h in logging.root.handlers:
+            logging.root.removeHandler(h)
+            h.close()
+
+    def test_setup_logger_debug(self):
+        self.clear_handlers()
+        cmd._setup_logger("DEBUG")
+        self.assertEqual(logging.root.level, logging.DEBUG)
+        self.assertEqual(logging.getLogger("httpx").level, logging.DEBUG)
+
+    def test_setup_logger_warn(self):
+        self.clear_handlers()
+        cmd._setup_logger("WARNING")
+        self.assertEqual(logging.root.level, logging.WARNING)
+        self.assertEqual(logging.getLogger("httpx").level, logging.WARNING)
 
 
 class DefaultDirTest:


### PR DESCRIPTION
Test coverage numbers looked like
```
Name                 Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------
drpg/__init__.py         3      0      0      0   100%
drpg/api.py             58      0     10      0   100%
drpg/cmd.py            131     27     36      5    80%   33-42, 48, 51, 56, 65->69, 192-207, 228, 236-238, 250-251
drpg/config.py          19      0      0      0   100%
drpg/sync.py           135      4     24      3    96%   59, 73, 76, 81->exit, 130
drpg/types.py           24      0      0      0   100%
tests/__init__.py        0      0      0      0   100%
tests/fixtures.py        8      0      0      0   100%
tests/test_api.py       87      0      0      0   100%
tests/test_cmd.py      112      0      2      0   100%
tests/test_sync.py     237      0      8      0   100%
----------------------------------------------------------------
TOTAL                  814     31     80      8    95%
```
The test files themselves shouldn't be part of the coverage numbers. This PR fixes that, and then adds enough extra tests to get back over the 95% threshold as this change dropped the coverage to 90%.