### PR TITLE
Optionally don't log up-to-date

### DIFF
--- a/drpg/cmd.py
+++ b/drpg/cmd.py
@@ -108,6 +108,13 @@ def _parse_cli(args: CliArgs | None = None) -> Config:
         default=environ.get("DRPG_NO_CHECK", "false").lower() == "false",
         help="Disable checking for updated version",
     )
+    parser.add_argument(
+        "--no-up-to-date",
+        action="store_false",
+        dest="log_up_to_date",
+        default=environ.get("DRPG_LOG_UP_TO_DATE", "false").lower() == "false",
+        help="Skip logging for up-to-date files",
+    )
 
     compability_group = parser.add_mutually_exclusive_group()
 

--- a/drpg/config.py
+++ b/drpg/config.py
@@ -17,6 +17,7 @@ class Config:
     omit_publisher: bool = False
     threads: int = 5
     do_check: bool = True
+    log_up_to_date: bool = True
 
     @classmethod
     def from_namespace(cls, namespace: Any) -> Config:
@@ -32,4 +33,5 @@ class Config:
             omit_publisher=namespace.omit_publisher,
             threads=namespace.threads,
             do_check=namespace.do_check,
+            log_up_to_date=namespace.log_up_to_date,
         )

--- a/drpg/sync.py
+++ b/drpg/sync.py
@@ -209,7 +209,8 @@ class DrpgSync:
             )
             return True
 
-        logger.info("Up to date: %s - %s", product["name"], item["filename"])
+        if self._config.log_up_to_date:
+            logger.info("Up to date: %s - %s", product["name"], item["filename"])
         return False
 
     def _file_path(self, product: Product, item: DownloadItem) -> Path:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -27,6 +27,7 @@ class dummy_config:
     compatibility_mode = False
     omit_publisher = False
     do_check = True
+    log_up_to_date = True
 
 
 PathMock = partial(mock.Mock, spec=Path)
@@ -74,32 +75,57 @@ class DrpgSyncNeedDownloadTest(TestCase):
         self.sync = drpg.DrpgSync(dummy_config)
 
     @mock.patch("drpg.DrpgSync._file_path", return_value=PathMock(**no_file_kwargs))
-    def test_no_local_file(self, _):
+    @mock.patch("drpg.sync.logger")
+    def test_no_local_file(self, logger: mock.MagicMock, _):
         item = self.dummy_item(self.old_date)
         product = self.dummy_product(item)
 
         need = self.sync._need_download(product, item)
         self.assertTrue(need)
+        logger.debug.assert_called_once_with(
+            "Needs download: %s - %s: local file does not exist", "Test rule book", "file.pdf"
+        )
 
     @mock.patch("drpg.DrpgSync._file_path", return_value=PathMock(**old_file_kwargs))
-    def test_local_last_modified_older(self, _):
+    @mock.patch("drpg.sync.logger")
+    def test_local_last_modified_older(self, logger: mock.MagicMock, _):
         item = self.dummy_item(self.new_date)
         product = self.dummy_product(item)
         product["fileLastModified"] = datetime.now().isoformat()
 
         need = self.sync._need_download(product, item)
         self.assertTrue(need)
+        logger.debug.assert_called_once_with(
+            "Needs download: %s - %s: local file is outdated", "Test rule book", "file.pdf"
+        )
 
     @mock.patch("drpg.DrpgSync._file_path", return_value=PathMock(**new_file_kwargs))
-    def test_local_last_modified_newer(self, _):
+    @mock.patch("drpg.sync.logger")
+    def test_local_last_modified_newer(self, logger: mock.MagicMock, _):
         item = self.dummy_item(self.old_date)
         product = self.dummy_product(item)
 
         need = self.sync._need_download(product, item)
         self.assertFalse(need)
+        logger.info.assert_called_once_with("Up to date: %s - %s", "Test rule book", "file.pdf")
 
     @mock.patch("drpg.DrpgSync._file_path", return_value=PathMock(**new_file_kwargs))
-    def test_md5_check(self, _):
+    @mock.patch("drpg.sync.logger")
+    def test_local_last_modified_newer_no_up_to_date(self, logger: mock.MagicMock, _):
+        item = self.dummy_item(self.old_date)
+        product = self.dummy_product(item)
+        self.sync._config.log_up_to_date = False
+
+        need = self.sync._need_download(product, item)
+        self.assertFalse(need)
+        logger.debug.assert_not_called()
+        logger.info.assert_not_called()
+
+        self.sync._config.log_up_to_date = True
+
+    @mock.patch("drpg.DrpgSync._file_path", return_value=PathMock(**new_file_kwargs))
+    @mock.patch("drpg.sync.logger")
+    def test_md5_check(self, logger: mock.MagicMock, _):
         self.sync._config.use_checksums = True
 
         with self.subTest("same md5"):
@@ -108,6 +134,9 @@ class DrpgSyncNeedDownloadTest(TestCase):
 
             need = self.sync._need_download(product, item)
             self.assertFalse(need)
+            logger.info.assert_called_once_with("Up to date: %s - %s", "Test rule book", "file.pdf")
+
+        logger.reset_mock()
 
         with self.subTest("different md5"):
             item = self.dummy_item(self.old_date)
@@ -116,6 +145,11 @@ class DrpgSyncNeedDownloadTest(TestCase):
 
             need = self.sync._need_download(product, item)
             self.assertTrue(need)
+            logger.debug.assert_called_once_with(
+                "Needs download: %s - %s: unmatching checksum", "Test rule book", "file.pdf"
+            )
+
+        logger.reset_mock()
 
         with self.subTest("remote file has no checksum"):
             item = self.dummy_item(self.old_date)
@@ -124,6 +158,7 @@ class DrpgSyncNeedDownloadTest(TestCase):
 
             need = self.sync._need_download(product, item)
             self.assertFalse(need)
+            logger.info.assert_called_once_with("Up to date: %s - %s", "Test rule book", "file.pdf")
 
     def dummy_item(self, date):
         file_md5 = md5(self.file_content).hexdigest()


### PR DESCRIPTION
I don't really care about up-to-date entries, only the missing/out-of-date ones, so add a config option to skip logging them