### PR TITLE
Need apt update before installing flatpak

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Build Python dependencies list
       working-directory: flatpak
       run: |
+        sudo apt update
         sudo apt install flatpak
         flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         flatpak install --user --assumeyes org.flatpak.Builder


### PR DESCRIPTION
Because that's what you should normally do. I forgot this when adding flatpak, apparently didn't have an issue, but [now it's breaking](https://github.com/glujan/drpg/actions/runs/29448076371/job/87463444031?pr=191)